### PR TITLE
Add Yahoo and DuckDuckGo as result providers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type SearchProviderType = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random';
  *
  * @export
  * @param {string} partialSearch The term to search suggestions for
- * @param {SearchEngine} searchProvider
+ * @param {SearchProviderType} searchProvider
  * @return {Promise<Suggestion[]>} The suggested searches
  */
 export async function getSuggestions(partialSearch: string, searchProvider: SearchProviderType = 'Google'): Promise<Suggestion[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import axios from 'axios';
 
-type SuggestResult = [
+type GoogleSuggestResult = [
   string,
   string[],
   [],
   string[],
   {
-    'google:clientdata': { 'bpc':boolean, 'tlw':boolean },
+    'google:clientdata': { 'bpc': boolean, 'tlw': boolean },
     'google:suggestrelevance': number[],
     'google:suggestsubtypes': number[][],
     'google:suggesttype': string[],
@@ -14,48 +14,158 @@ type SuggestResult = [
   },
 ];
 
+type DuckDuckGoSuggestResult = {
+  'phrase': string
+}[]
+
+type YahooSuggestResult = {
+  q: string,
+  l: {
+    gprid: string
+  },
+  r: {
+    'k': string,
+    'm': number
+  }[]
+}
 type SuggestionType = 'QUERY' | 'NAVIGATION';
+type SearchEngine = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random'
+/**
+ * Gets search suggestions for a partial search
+ *
+ * @export
+ * @param {string} partialSearch The term to search suggestions for
+ * @param {SearchEngine} searchEngine
+ * @return {Promise<Suggestion[]>} The suggested searches
+ */
+ export async function getSuggestions(partialSearch: string, searchEngine: SearchEngine = "Google"): Promise<Suggestion[]> {
+  if (searchEngine == 'random') {
+    const engines = ['Google','Yahoo','DuckDuckGo']
+    searchEngine = engines[Math.floor(Math.random()*engines.length)] as SearchEngine
+  }
+  switch (searchEngine) {
+    case 'DuckDuckGo':
+      return new DuckDuckGo().getSuggestions(partialSearch)
+    case 'Yahoo':
+      return new Yahoo().getSuggestions(partialSearch)
+    default:
+      return new Google().getSuggestions(partialSearch)
+  }
+};
 
 export interface Suggestion {
   term: string,
   type: SuggestionType
 }
 
-/**
- * Gets the URL to query the autosuggest service
- *
- * @param {string} searchTerm
- * @return {string}
- */
-function getUrl(searchTerm: string): string {
-  return `http://suggestqueries.google.com/complete/search?client=chrome&q=${searchTerm}`;
+interface BaseSearch {
+  getUrl(searchTerm: string): string
+  getSuggestions(partialSearch: string): Promise<Suggestion[]>
 }
 
-/**
- * Type enforce the suggestion type
- *
- * @param {string} typeStr
- * @return {SuggestionType}
- */
-function getSuggestionType(typeStr: string): SuggestionType {
-  return typeStr === 'QUERY' ? 'QUERY' : 'NAVIGATION';
+export class Google implements BaseSearch {
+  /**
+   * Type enforce the suggestion type
+   *
+   * @param {string} typeStr
+   * @return {SuggestionType}
+   */
+  getSuggestionType(typeStr: string): SuggestionType {
+    return typeStr === 'QUERY' ? 'QUERY' : 'NAVIGATION';
+  }
+
+  /**
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  getUrl(searchTerm: string): string {
+    return `http://suggestqueries.google.com/complete/search?client=chrome&q=${searchTerm}`;
+  }
+  /**
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
+
+    const res = await axios(url);
+    const suggestions = await res.data as GoogleSuggestResult;
+
+    return suggestions[1].map((suggestion, index) => ({
+      term: suggestion,
+      type: this.getSuggestionType(suggestions[4]['google:suggesttype'][index]),
+    }));
+  }
 }
 
-/**
- * Gets search suggestions for a partial search
- *
- * @export
- * @param {string} partialSearch The term to search suggestions for
- * @return {Promise<Suggestion[]>} The suggested searches
- */
-export async function getSuggestions(partialSearch: string): Promise<Suggestion[]> {
-  const url = getUrl(partialSearch);
+export class DuckDuckGo implements BaseSearch {
+  /**
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  getUrl(searchTerm: string): string {
+    return `https://duckduckgo.com/ac/?q=${searchTerm}&kl=wt-wt`;
+  }
+  /**
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
 
-  const res = await axios(url);
-  const suggestions = await res.data as SuggestResult;
+    const res = await axios(url);
+    const suggestions = await res.data as DuckDuckGoSuggestResult;
 
-  return suggestions[1].map((suggestion, index) => ({
-    term: suggestion,
-    type: getSuggestionType(suggestions[4]['google:suggesttype'][index]),
-  }));
+    return suggestions.map((suggestion) => ({
+      term: suggestion.phrase,
+      type: 'QUERY',
+    }));
+  }
+}
+
+export class Yahoo implements BaseSearch {
+
+  /**
+   * Type enforce the suggestion type
+   *
+   * @param {number} typeNum
+   * @return {SuggestionType}
+   */
+  getSuggestionType(typeNum: number): SuggestionType {
+    return typeNum === 6 ? 'QUERY' : 'NAVIGATION';
+  }
+  /**
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  getUrl(searchTerm: string): string {
+    return `https://search.yahoo.com/sugg/gossip/gossip-us-ura/?command=${searchTerm}&output=sd1&appid=yfp-t&nresults=10&pq=`;
+  }
+  /**
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
+
+    const res = await axios(url);
+    const suggestions = await res.data as YahooSuggestResult;
+
+    return suggestions.r.map((suggestion) => ({
+      term: suggestion.k,
+      type: this.getSuggestionType(suggestion.m),
+    }));
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { Suggestion } from './providers/base';
-
 import { DuckDuckGo } from './providers/DuckDuckGo';
 import { Google } from './providers/Google';
 import { Yahoo } from './providers/Yahoo';
 
 export type SearchProviderType = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random';
+
 /**
  * Gets search suggestions for a partial search
  *
@@ -15,16 +15,18 @@ export type SearchProviderType = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random';
  */
 export async function getSuggestions(partialSearch: string, searchProvider: SearchProviderType = 'Google'): Promise<Suggestion[]> {
   let provider = searchProvider;
+
   if (provider === 'random') {
     const providers = ['Google', 'Yahoo', 'DuckDuckGo'];
     provider = providers[Math.floor(Math.random() * providers.length)] as SearchProviderType;
   }
+
   switch (provider) {
     case 'DuckDuckGo':
-      return new DuckDuckGo().getSuggestions(partialSearch);
+      return DuckDuckGo.getSuggestions(partialSearch);
     case 'Yahoo':
-      return new Yahoo().getSuggestions(partialSearch);
+      return Yahoo.getSuggestions(partialSearch);
     default:
-      return new Google().getSuggestions(partialSearch);
+      return Google.getSuggestions(partialSearch);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,171 +1,30 @@
-import axios from 'axios';
+import { Suggestion } from './providers/base';
 
-type GoogleSuggestResult = [
-  string,
-  string[],
-  [],
-  string[],
-  {
-    'google:clientdata': { 'bpc': boolean, 'tlw': boolean },
-    'google:suggestrelevance': number[],
-    'google:suggestsubtypes': number[][],
-    'google:suggesttype': string[],
-    'google:verbatimrelevance': number
-  },
-];
+import { DuckDuckGo } from './providers/DuckDuckGo';
+import { Google } from './providers/Google';
+import { Yahoo } from './providers/Yahoo';
 
-type DuckDuckGoSuggestResult = {
-  'phrase': string
-}[]
-
-type YahooSuggestResult = {
-  q: string,
-  l: {
-    gprid: string
-  },
-  r: {
-    'k': string,
-    'm': number
-  }[]
-}
-type SuggestionType = 'QUERY' | 'NAVIGATION';
-type SearchEngine = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random'
+export type SearchProviderType = 'Google' | 'Yahoo' | 'DuckDuckGo' | 'random';
 /**
  * Gets search suggestions for a partial search
  *
  * @export
  * @param {string} partialSearch The term to search suggestions for
- * @param {SearchEngine} searchEngine
+ * @param {SearchEngine} searchProvider
  * @return {Promise<Suggestion[]>} The suggested searches
  */
- export async function getSuggestions(partialSearch: string, searchEngine: SearchEngine = "Google"): Promise<Suggestion[]> {
-  if (searchEngine == 'random') {
-    const engines = ['Google','Yahoo','DuckDuckGo']
-    searchEngine = engines[Math.floor(Math.random()*engines.length)] as SearchEngine
+export async function getSuggestions(partialSearch: string, searchProvider: SearchProviderType = 'Google'): Promise<Suggestion[]> {
+  let provider = searchProvider;
+  if (provider === 'random') {
+    const providers = ['Google', 'Yahoo', 'DuckDuckGo'];
+    provider = providers[Math.floor(Math.random() * providers.length)] as SearchProviderType;
   }
-  switch (searchEngine) {
+  switch (provider) {
     case 'DuckDuckGo':
-      return new DuckDuckGo().getSuggestions(partialSearch)
+      return new DuckDuckGo().getSuggestions(partialSearch);
     case 'Yahoo':
-      return new Yahoo().getSuggestions(partialSearch)
+      return new Yahoo().getSuggestions(partialSearch);
     default:
-      return new Google().getSuggestions(partialSearch)
-  }
-};
-
-export interface Suggestion {
-  term: string,
-  type: SuggestionType
-}
-
-interface BaseSearch {
-  getUrl(searchTerm: string): string
-  getSuggestions(partialSearch: string): Promise<Suggestion[]>
-}
-
-export class Google implements BaseSearch {
-  /**
-   * Type enforce the suggestion type
-   *
-   * @param {string} typeStr
-   * @return {SuggestionType}
-   */
-  getSuggestionType(typeStr: string): SuggestionType {
-    return typeStr === 'QUERY' ? 'QUERY' : 'NAVIGATION';
-  }
-
-  /**
-   * Gets the URL to query the autosuggest service
-   *
-   * @param {string} searchTerm
-   * @return {string}
-   */
-  getUrl(searchTerm: string): string {
-    return `http://suggestqueries.google.com/complete/search?client=chrome&q=${searchTerm}`;
-  }
-  /**
-   * Gets search suggestions for a partial search
-   *
-   * @param {string} partialSearch The term to search suggestions for
-   * @return {Promise<Suggestion[]>} The suggested searches
-   */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
-    const url = this.getUrl(partialSearch);
-
-    const res = await axios(url);
-    const suggestions = await res.data as GoogleSuggestResult;
-
-    return suggestions[1].map((suggestion, index) => ({
-      term: suggestion,
-      type: this.getSuggestionType(suggestions[4]['google:suggesttype'][index]),
-    }));
-  }
-}
-
-export class DuckDuckGo implements BaseSearch {
-  /**
-   * Gets the URL to query the autosuggest service
-   *
-   * @param {string} searchTerm
-   * @return {string}
-   */
-  getUrl(searchTerm: string): string {
-    return `https://duckduckgo.com/ac/?q=${searchTerm}&kl=wt-wt`;
-  }
-  /**
-   * Gets search suggestions for a partial search
-   *
-   * @param {string} partialSearch The term to search suggestions for
-   * @return {Promise<Suggestion[]>} The suggested searches
-   */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
-    const url = this.getUrl(partialSearch);
-
-    const res = await axios(url);
-    const suggestions = await res.data as DuckDuckGoSuggestResult;
-
-    return suggestions.map((suggestion) => ({
-      term: suggestion.phrase,
-      type: 'QUERY',
-    }));
-  }
-}
-
-export class Yahoo implements BaseSearch {
-
-  /**
-   * Type enforce the suggestion type
-   *
-   * @param {number} typeNum
-   * @return {SuggestionType}
-   */
-  getSuggestionType(typeNum: number): SuggestionType {
-    return typeNum === 6 ? 'QUERY' : 'NAVIGATION';
-  }
-  /**
-   * Gets the URL to query the autosuggest service
-   *
-   * @param {string} searchTerm
-   * @return {string}
-   */
-  getUrl(searchTerm: string): string {
-    return `https://search.yahoo.com/sugg/gossip/gossip-us-ura/?command=${searchTerm}&output=sd1&appid=yfp-t&nresults=10&pq=`;
-  }
-  /**
-   * Gets search suggestions for a partial search
-   *
-   * @param {string} partialSearch The term to search suggestions for
-   * @return {Promise<Suggestion[]>} The suggested searches
-   */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
-    const url = this.getUrl(partialSearch);
-
-    const res = await axios(url);
-    const suggestions = await res.data as YahooSuggestResult;
-
-    return suggestions.r.map((suggestion) => ({
-      term: suggestion.k,
-      type: this.getSuggestionType(suggestion.m),
-    }));
+      return new Google().getSuggestions(partialSearch);
   }
 }

--- a/src/providers/DuckDuckGo.ts
+++ b/src/providers/DuckDuckGo.ts
@@ -5,24 +5,24 @@ export type DuckDuckGoSuggestResult = {
   'phrase': string
 }[];
 
-export class DuckDuckGo implements BaseProvider {
+export class DuckDuckGo extends BaseProvider {
   /**
-     * Gets the URL to query the autosuggest service
-     *
-     * @param {string} searchTerm
-     * @return {string}
-     */
-  getUrl(searchTerm: string): string {
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  static getUrl(searchTerm: string): string {
     return `https://duckduckgo.com/ac/?q=${searchTerm}&kl=wt-wt`;
   }
 
   /**
-     * Gets search suggestions for a partial search
-     *
-     * @param {string} partialSearch The term to search suggestions for
-     * @return {Promise<Suggestion[]>} The suggested searches
-     */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  static async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
     const url = this.getUrl(partialSearch);
 
     const res = await axios(url);

--- a/src/providers/DuckDuckGo.ts
+++ b/src/providers/DuckDuckGo.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { BaseProvider, Suggestion } from './base';
+
+export type DuckDuckGoSuggestResult = {
+  'phrase': string
+}[];
+
+export class DuckDuckGo implements BaseProvider {
+  /**
+     * Gets the URL to query the autosuggest service
+     *
+     * @param {string} searchTerm
+     * @return {string}
+     */
+  getUrl(searchTerm: string): string {
+    return `https://duckduckgo.com/ac/?q=${searchTerm}&kl=wt-wt`;
+  }
+
+  /**
+     * Gets search suggestions for a partial search
+     *
+     * @param {string} partialSearch The term to search suggestions for
+     * @return {Promise<Suggestion[]>} The suggested searches
+     */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
+
+    const res = await axios(url);
+    const suggestions = await res.data as DuckDuckGoSuggestResult;
+
+    return suggestions.map((suggestion) => ({
+      term: suggestion.phrase,
+      type: 'QUERY',
+    }));
+  }
+}

--- a/src/providers/Google.ts
+++ b/src/providers/Google.ts
@@ -15,34 +15,34 @@ export type GoogleSuggestResult = [
   },
 ];
 
-export class Google implements BaseProvider {
+export class Google extends BaseProvider {
   /**
-     * Type enforce the suggestion type
-     *
-     * @param {string} typeStr
-     * @return {SuggestionType}
-     */
+   * Type enforce the suggestion type
+   *
+   * @param {string} typeStr
+   * @return {SuggestionType}
+   */
   static getSuggestionType(typeStr: string): SuggestionType {
     return typeStr === 'QUERY' ? 'QUERY' : 'NAVIGATION';
   }
 
   /**
-     * Gets the URL to query the autosuggest service
-     *
-     * @param {string} searchTerm
-     * @return {string}
-     */
-  getUrl(searchTerm: string): string {
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  static getUrl(searchTerm: string): string {
     return `http://suggestqueries.google.com/complete/search?client=chrome&q=${searchTerm}`;
   }
 
   /**
-     * Gets search suggestions for a partial search
-     *
-     * @param {string} partialSearch The term to search suggestions for
-     * @return {Promise<Suggestion[]>} The suggested searches
-     */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  static async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
     const url = this.getUrl(partialSearch);
 
     const res = await axios(url);

--- a/src/providers/Google.ts
+++ b/src/providers/Google.ts
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import { SuggestionType, BaseProvider, Suggestion } from './base';
+
+export type GoogleSuggestResult = [
+  string,
+  string[],
+  [],
+  string[],
+  {
+    'google:clientdata': { 'bpc': boolean, 'tlw': boolean },
+    'google:suggestrelevance': number[],
+    'google:suggestsubtypes': number[][],
+    'google:suggesttype': string[],
+    'google:verbatimrelevance': number
+  },
+];
+
+export class Google implements BaseProvider {
+  /**
+     * Type enforce the suggestion type
+     *
+     * @param {string} typeStr
+     * @return {SuggestionType}
+     */
+  static getSuggestionType(typeStr: string): SuggestionType {
+    return typeStr === 'QUERY' ? 'QUERY' : 'NAVIGATION';
+  }
+
+  /**
+     * Gets the URL to query the autosuggest service
+     *
+     * @param {string} searchTerm
+     * @return {string}
+     */
+  getUrl(searchTerm: string): string {
+    return `http://suggestqueries.google.com/complete/search?client=chrome&q=${searchTerm}`;
+  }
+
+  /**
+     * Gets search suggestions for a partial search
+     *
+     * @param {string} partialSearch The term to search suggestions for
+     * @return {Promise<Suggestion[]>} The suggested searches
+     */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
+
+    const res = await axios(url);
+    const suggestions = await res.data as GoogleSuggestResult;
+
+    return suggestions[1].map((suggestion, index) => ({
+      term: suggestion,
+      type: Google.getSuggestionType(suggestions[4]['google:suggesttype'][index]),
+    }));
+  }
+}

--- a/src/providers/Yahoo.ts
+++ b/src/providers/Yahoo.ts
@@ -12,7 +12,7 @@ export type YahooSuggestResult = {
   }[]
 };
 
-export class Yahoo implements BaseProvider {
+export class Yahoo extends BaseProvider {
   /**
      * Type enforce the suggestion type
      *
@@ -24,22 +24,22 @@ export class Yahoo implements BaseProvider {
   }
 
   /**
-     * Gets the URL to query the autosuggest service
-     *
-     * @param {string} searchTerm
-     * @return {string}
-     */
-  getUrl(searchTerm: string): string {
+   * Gets the URL to query the autosuggest service
+   *
+   * @param {string} searchTerm
+   * @return {string}
+   */
+  static getUrl(searchTerm: string): string {
     return `https://search.yahoo.com/sugg/gossip/gossip-us-ura/?command=${searchTerm}&output=sd1&appid=yfp-t&nresults=10&pq=`;
   }
 
   /**
-     * Gets search suggestions for a partial search
-     *
-     * @param {string} partialSearch The term to search suggestions for
-     * @return {Promise<Suggestion[]>} The suggested searches
-     */
-  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+   * Gets search suggestions for a partial search
+   *
+   * @param {string} partialSearch The term to search suggestions for
+   * @return {Promise<Suggestion[]>} The suggested searches
+   */
+  static async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
     const url = this.getUrl(partialSearch);
 
     const res = await axios(url);

--- a/src/providers/Yahoo.ts
+++ b/src/providers/Yahoo.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import { SuggestionType, BaseProvider, Suggestion } from './base';
+
+export type YahooSuggestResult = {
+  q: string,
+  l: {
+    gprid: string
+  },
+  r: {
+    'k': string,
+    'm': number
+  }[]
+};
+
+export class Yahoo implements BaseProvider {
+  /**
+     * Type enforce the suggestion type
+     *
+     * @param {number} typeNum
+     * @return {SuggestionType}
+     */
+  static getSuggestionType(typeNum: number): SuggestionType {
+    return typeNum === 6 ? 'QUERY' : 'NAVIGATION';
+  }
+
+  /**
+     * Gets the URL to query the autosuggest service
+     *
+     * @param {string} searchTerm
+     * @return {string}
+     */
+  getUrl(searchTerm: string): string {
+    return `https://search.yahoo.com/sugg/gossip/gossip-us-ura/?command=${searchTerm}&output=sd1&appid=yfp-t&nresults=10&pq=`;
+  }
+
+  /**
+     * Gets search suggestions for a partial search
+     *
+     * @param {string} partialSearch The term to search suggestions for
+     * @return {Promise<Suggestion[]>} The suggested searches
+     */
+  async getSuggestions(partialSearch: string): Promise<Suggestion[]> {
+    const url = this.getUrl(partialSearch);
+
+    const res = await axios(url);
+    const suggestions = await res.data as YahooSuggestResult;
+
+    return suggestions.r.map((suggestion) => ({
+      term: suggestion.k,
+      type: Yahoo.getSuggestionType(suggestion.m),
+    }));
+  }
+}

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -5,7 +5,8 @@ export interface Suggestion {
   type: SuggestionType
 }
 
-export interface BaseProvider {
-  getUrl(searchTerm: string): string
-  getSuggestions(partialSearch: string): Promise<Suggestion[]>
+export abstract class BaseProvider {
+  static getUrl: (searchTerm: string) => string;
+
+  static getSuggestions: (partialSearch: string) => Promise<Suggestion[]>;
 }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,0 +1,11 @@
+export type SuggestionType = 'QUERY' | 'NAVIGATION';
+
+export interface Suggestion {
+  term: string,
+  type: SuggestionType
+}
+
+export interface BaseProvider {
+  getUrl(searchTerm: string): string
+  getSuggestions(partialSearch: string): Promise<Suggestion[]>
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,14 +1,55 @@
-import { getSuggestions } from '../src';
-
-describe('Test getting suggestions', () => {
+import { getSuggestions } from '../src'
+describe('Test getting Google suggestions', () => {
   it('Should return suggestions for common search terms', async () => {
-    const suggestions = await getSuggestions('hotels');
+    const suggestions = await getSuggestions('hotels', 'Google');
 
     expect(suggestions.length).toBeGreaterThan(0);
   });
 
   it('Should should not return suggestions for weird search terms', async () => {
-    const suggestions = await getSuggestions('saduqlkjasdku,ylkajsdkhasd');
+    const suggestions = await getSuggestions('aduqlkjasdku,ylkajsdkhasd', 'Google');
+
+    expect(suggestions.length).toBe(0);
+  });
+});
+
+describe('Test getting DuckDuckGo suggestions', () => {
+  it('Should return suggestions for common search terms', async () => {
+    const suggestions = await getSuggestions('hotels', 'DuckDuckGo');
+
+    expect(suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('Should should not return suggestions for weird search terms', async () => {
+    const suggestions = await getSuggestions('saduqlkjasdku,ylkajsdkhasd', 'DuckDuckGo');
+
+    expect(suggestions.length).toBe(0);
+  });
+});
+
+describe('Test getting Yahoo suggestions', () => {
+  it('Should return suggestions for common search terms', async () => {
+    const suggestions = await getSuggestions('hotels', 'Yahoo');
+
+    expect(suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('Should should not return suggestions for weird search terms', async () => {
+    const suggestions = await getSuggestions('saduqlkjasdku,ylkajsdkhasd', 'Yahoo');
+
+    expect(suggestions.length).toBe(0);
+  });
+});
+
+describe('Test getting random suggestions', () => {
+  it('Should return suggestions for common search terms', async () => {
+    const suggestions = await getSuggestions('hotels', 'random');
+
+    expect(suggestions.length).toBeGreaterThan(0);
+  });
+
+  it('Should should not return suggestions for weird search terms', async () => {
+    const suggestions = await getSuggestions('saduqlkjasdku,ylkajsdkhasd', 'random');
 
     expect(suggestions.length).toBe(0);
   });


### PR DESCRIPTION
This PR adds Yahoo and DuckDuckGo as alternative result providers.
It also adds tests for these providers and should not introduce breaking changes for anyone using previous versions of the module. Let me know if there's any documentation that I should update as well as if there's any changes I would need to make.